### PR TITLE
Update htslib dep minimally to fix build issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ quick-error = "*"
 regex = "0.2"
 multimap = "0.4"
 fxhash = "0.1.2"
-rust-htslib = "0.12.1"
+rust-htslib = "0.13.0"
 
 [dependencies.vec_map]
 version = "0.8"


### PR DESCRIPTION
Some changes were made to the build script in rust-htslib 0.13.0 that seem to fix problems with finding the static libhts when compiling.